### PR TITLE
conform type validation with openapi3

### DIFF
--- a/jsoninfo/marshal_test.go
+++ b/jsoninfo/marshal_test.go
@@ -1,12 +1,12 @@
 package jsoninfo_test
 
 import (
-	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi3"
 )
 
 import (
 	"encoding/json"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 	"testing"
 	"time"
 )

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -9,7 +9,7 @@ package openapi2
 
 import (
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi3"
 )
 
 type Swagger struct {

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -3,8 +3,8 @@ package openapi2conv
 
 import (
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi2"
-	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi2"
+	"github.com/ronniedada/kin-openapi/openapi3"
 	"net/url"
 )
 

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -3,10 +3,10 @@ package openapi2conv_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi2"
-	"github.com/jban332/kin-openapi/openapi2conv"
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-test/jsontest"
+	"github.com/ronniedada/kin-openapi/openapi2"
+	"github.com/ronniedada/kin-openapi/openapi2conv"
+	"github.com/ronniedada/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-test/jsontest"
 	"testing"
 )
 

--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -3,7 +3,7 @@ package openapi3
 import (
 	"context"
 	"fmt"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 	"regexp"
 )
 

--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 	"strings"
 )
 

--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -89,6 +89,9 @@ func (value *ContentType) UnmarshalJSON(data []byte) error {
 }
 
 func (ct *ContentType) Validate(c context.Context) error {
+	if ct == nil {
+		return nil
+	}
 	if schema := ct.Schema; schema != nil {
 		if err := schema.Validate(c); err != nil {
 			return err

--- a/openapi3/extension.go
+++ b/openapi3/extension.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"encoding/json"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 // ExtensionProps provides support for OpenAPI extensions.

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -1,7 +1,7 @@
 package openapi3
 
 import (
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 // Info is specified by OpenAPI/Swagger standard version 3.0.

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 // Link is specified by OpenAPI/Swagger standard version 3.0.

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 	"strconv"
 )
 

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -3,7 +3,7 @@ package openapi3
 import (
 	"context"
 	"fmt"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 // Parameters is specified by OpenAPI/Swagger 3.0 standard.

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -3,7 +3,7 @@ package openapi3
 import (
 	"context"
 	"fmt"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 type PathItem struct {

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 type CallbackRef struct {

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 // RequestBody is specified by OpenAPI/Swagger 3.0 standard.

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 	"strconv"
 )
 

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 	"math"
 	"regexp"
 	"strconv"

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -379,16 +379,14 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 	schemaType := schema.Type
 	switch schemaType {
 	case "":
-	case "boolean":
-	case "number":
-		if format := schema.Format; len(format) > 0 {
-			switch format {
-			case "int32", "int64", "float", "double":
-			default:
-				return fmt.Errorf("Unsupported 'format' value '%v", format)
-			}
-		}
+	case "integer", "long", "float", "double":
 	case "string":
+	case "byte":
+	case "binary":
+	case "boolean":
+	case "date":
+	case "dateTime":
+	case "password":
 	case "array":
 		if schema.Items == nil {
 			return fmt.Errorf("When schema type is 'array', schema 'items' must be non-null")

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -2,8 +2,8 @@ package openapi3_test
 
 import (
 	"encoding/base64"
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-test/jsontest"
+	"github.com/ronniedada/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-test/jsontest"
 	"testing"
 )
 

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 type SecurityScheme struct {

--- a/openapi3/server_test.go
+++ b/openapi3/server_test.go
@@ -1,8 +1,8 @@
 package openapi3_test
 
 import (
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-test/jsontest"
+	"github.com/ronniedada/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-test/jsontest"
 	"testing"
 )
 

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
 )
 
 type Swagger struct {

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -354,6 +354,9 @@ func (resolver *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *R
 	}
 	if content := value.Content; content != nil {
 		for _, contentType := range content {
+			if contentType == nil {
+				continue
+			}
 			if schema := contentType.Schema; schema != nil {
 				err := resolver.resolveSchemaRef(swagger, schema)
 				if err != nil {

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -2,7 +2,7 @@ package openapi3_test
 
 import (
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi3"
 )
 
 func ExampleSwaggerLoader() {

--- a/openapi3/swagger_test.go
+++ b/openapi3/swagger_test.go
@@ -3,8 +3,8 @@ package openapi3_test
 import (
 	"context"
 	"encoding/json"
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-test/jsontest"
+	"github.com/ronniedada/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-test/jsontest"
 	"testing"
 )
 

--- a/openapi3filter/authentication_input.go
+++ b/openapi3filter/authentication_input.go
@@ -2,7 +2,7 @@ package openapi3filter
 
 import (
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi3"
 	"strings"
 )
 

--- a/openapi3filter/errors.go
+++ b/openapi3filter/errors.go
@@ -3,7 +3,7 @@ package openapi3filter
 import (
 	"errors"
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi3"
 	"net/http"
 )
 

--- a/openapi3filter/router.go
+++ b/openapi3filter/router.go
@@ -2,8 +2,8 @@ package openapi3filter
 
 import (
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-openapi/pathpattern"
+	"github.com/ronniedada/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/pathpattern"
 	"net/http"
 	"net/url"
 	"strings"

--- a/openapi3filter/router_test.go
+++ b/openapi3filter/router_test.go
@@ -1,8 +1,8 @@
 package openapi3filter_test
 
 import (
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-openapi/openapi3filter"
+	"github.com/ronniedada/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi3filter"
 	"net/http"
 	"sort"
 	"testing"

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi3"
 	"io/ioutil"
 	"net/http"
 	"sort"

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -18,6 +18,9 @@ func ValidateRequest(c context.Context, input *RequestValidationInput) error {
 	}
 	route := input.Route
 	operation := route.Operation
+	if route == nil {
+		return fmt.Errorf("invalid route")
+	}
 	if operation == nil {
 		return errRouteMissingOperation
 	}

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -3,9 +3,9 @@ package openapi3filter_test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-openapi/openapi3filter"
-	"github.com/jban332/kin-test/jsontest"
+	"github.com/ronniedada/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/openapi3filter"
+	"github.com/ronniedada/kin-test/jsontest"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -3,8 +3,8 @@ package openapi3gen
 
 import (
 	"encoding/json"
-	"github.com/jban332/kin-openapi/jsoninfo"
-	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/ronniedada/kin-openapi/jsoninfo"
+	"github.com/ronniedada/kin-openapi/openapi3"
 	"reflect"
 	"strings"
 	"time"

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -2,8 +2,8 @@ package openapi3gen_test
 
 import (
 	"encoding/json"
-	"github.com/jban332/kin-openapi/openapi3gen"
-	"github.com/jban332/kin-test/jsontest"
+	"github.com/ronniedada/kin-openapi/openapi3gen"
+	"github.com/ronniedada/kin-test/jsontest"
 	"testing"
 	"time"
 )

--- a/pathpattern/node_test.go
+++ b/pathpattern/node_test.go
@@ -1,7 +1,7 @@
 package pathpattern_test
 
 import (
-	"github.com/jban332/kin-openapi/pathpattern"
+	"github.com/ronniedada/kin-openapi/pathpattern"
 	"testing"
 )
 


### PR DESCRIPTION
- validate types supported in openapi 3.0
- handle cases where response content schema is empty