### PR TITLE
 conform type validation with openapi3

### DIFF
--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -89,6 +89,9 @@ func (value *ContentType) UnmarshalJSON(data []byte) error {
 }
 
 func (ct *ContentType) Validate(c context.Context) error {
+	if ct == nil {
+		return nil
+	}
 	if schema := ct.Schema; schema != nil {
 		if err := schema.Validate(c); err != nil {
 			return err

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -379,16 +379,14 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 	schemaType := schema.Type
 	switch schemaType {
 	case "":
-	case "boolean":
-	case "number":
-		if format := schema.Format; len(format) > 0 {
-			switch format {
-			case "int32", "int64", "float", "double":
-			default:
-				return fmt.Errorf("Unsupported 'format' value '%v", format)
-			}
-		}
+	case "integer", "long", "float", "double":
 	case "string":
+	case "byte":
+	case "binary":
+	case "boolean":
+	case "date":
+	case "dateTime":
+	case "password":
 	case "array":
 		if schema.Items == nil {
 			return fmt.Errorf("When schema type is 'array', schema 'items' must be non-null")

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -354,6 +354,9 @@ func (resolver *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *R
 	}
 	if content := value.Content; content != nil {
 		for _, contentType := range content {
+			if contentType == nil {
+				continue
+			}
 			if schema := contentType.Schema; schema != nil {
 				err := resolver.resolveSchemaRef(swagger, schema)
 				if err != nil {

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -17,6 +17,9 @@ func ValidateRequest(c context.Context, input *RequestValidationInput) error {
 		options = DefaultOptions
 	}
 	route := input.Route
+	if route == nil {
+		return fmt.Errorf("invalid route")
+	}
 	operation := route.Operation
 	if operation == nil {
 		return errRouteMissingOperation


### PR DESCRIPTION

- validate types supported in openapi 3.0
- handle cases where response content schema is empty