### PR TITLE
lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
-
+go_import_path: github.com/jban332/kin-openapi
 go:
+- 1.10.x
 - 1.8.x

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This library provides packages for dealing with OpenAPI specifications.
 ## Loading OpenAPI document
 Use `SwaggerLoader`, which resolves all JSON references:
 ```go
-swagger, err := openapi3.NewSwaggerLoader().LoadFromFile("swagger.json")
+swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromFile("swagger.json")
 ```
 
 ## Getting OpenAPI operation that matches request

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This library provides packages for dealing with OpenAPI specifications.
 # Packages
   * `jsoninfo`
     * Provides information and functions for marshalling/unmarshalling JSON. The purpose is a clutter-free implementation of JSON references and OpenAPI extension properties.
-  * `openapi2` 
+  * `openapi2`
     * Parses/writes OpenAPI 2.
   * `openapi2conv`
     * Converts OpenAPI 2 specification into OpenAPI 3 specification.
@@ -45,7 +45,7 @@ This library provides packages for dealing with OpenAPI specifications.
     * Parses/writes OpenAPI 3. Includes OpenAPI schema / JSON schema valdation.
   * `openapi3filter`
     * Validates that HTTP request and HTTP response match an OpenAPI specification file.
-  * `openapi3gen` 
+  * `openapi3gen`
     * Generates OpenAPI 3 schemas for Go types.
   * `pathpattern`
     * Support for OpenAPI style path patterns.
@@ -59,7 +59,7 @@ swagger, err := openapi3.NewSwaggerLoader().LoadFromFile("swagger.json")
 ```
 
 ## Getting OpenAPI operation that matches request
-```go 
+```go
 func GetOperation(httpRequest *http.Request) (*openapi3.Operation, error) {
   // Load Swagger file
   router := openapi3filter.NewRouter().WithSwaggerFromFile("swagger.json")
@@ -78,9 +78,10 @@ func GetOperation(httpRequest *http.Request) (*openapi3.Operation, error) {
 ## Validating HTTP requests/responses
 ```go
 import (
+  "net/http"
+
   "github.com/jban332/kin-openapi/openapi3"
   "github.com/jban332/kin-openapi/openapi3filter"
-  "net/http"
 )
 
 var router = openapi3filter.NewRouter().WithSwaggerFromFile("swagger.json")
@@ -90,7 +91,7 @@ func ValidateRequest(req *http.Request) {
     Request: req,
     Router:  router,
   })
-  
+
   // Get response
 
   openapi3filter.ValidateResponse(nil, &openapi3filter.ValidateResponseInput {
@@ -108,7 +109,7 @@ Usage looks like:
 type Example struct {
   // Allow extension properties ("x-someProperty")
   openapi3.ExtensionProps
-  
+
   // Normal properties
   SomeField float64
 }

--- a/jsoninfo/field_info.go
+++ b/jsoninfo/field_info.go
@@ -11,13 +11,13 @@ import (
 type FieldInfo struct {
 	MultipleFields     bool // Whether multiple Go fields share this JSON name
 	HasJSONTag         bool
-	Index              []int
-	Type               reflect.Type
 	TypeIsMarshaller   bool
 	TypeIsUnmarshaller bool
-	JSONName           string
 	JSONOmitEmpty      bool
 	JSONString         bool
+	Index              []int
+	Type               reflect.Type
+	JSONName           string
 }
 
 func AppendFields(fields []FieldInfo, parentIndex []int, t reflect.Type) []FieldInfo {

--- a/jsoninfo/marshal.go
+++ b/jsoninfo/marshal.go
@@ -11,8 +11,7 @@ import (
 //   * Correctly handles StrictStruct semantics.
 func MarshalStrictStruct(value StrictStruct) ([]byte, error) {
 	encoder := NewObjectEncoder()
-	err := value.EncodeWith(encoder, value)
-	if err != nil {
+	if err := value.EncodeWith(encoder, value); err != nil {
 		return nil, err
 	}
 	return encoder.Bytes()

--- a/jsoninfo/marshal.go
+++ b/jsoninfo/marshal.go
@@ -121,11 +121,11 @@ iteration:
 			}
 		case reflect.Bool:
 			x := fieldValue.Bool()
-			if field.JSONOmitEmpty && x == false {
+			if field.JSONOmitEmpty && !x {
 				continue iteration
 			}
 			s := "false"
-			if x == true {
+			if x {
 				s = "true"
 			}
 			result[field.JSONName] = []byte(s)

--- a/jsoninfo/marshal_ref.go
+++ b/jsoninfo/marshal_ref.go
@@ -15,8 +15,7 @@ func MarshalRef(value string, otherwise interface{}) ([]byte, error) {
 
 func UnmarshalRef(data []byte, destRef *string, destOtherwise interface{}) error {
 	refProps := &refProps{}
-	err := json.Unmarshal(data, refProps)
-	if err == nil {
+	if err := json.Unmarshal(data, refProps); err == nil {
 		ref := refProps.Ref
 		if len(ref) > 0 {
 			*destRef = ref

--- a/jsoninfo/marshal_test.go
+++ b/jsoninfo/marshal_test.go
@@ -1,14 +1,12 @@
 package jsoninfo_test
 
 import (
-	"github.com/jban332/kin-openapi/openapi3"
-)
-
-import (
 	"encoding/json"
-	"github.com/jban332/kin-openapi/jsoninfo"
 	"testing"
 	"time"
+
+	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/jban332/kin-openapi/openapi3"
 )
 
 type Simple struct {

--- a/jsoninfo/marshal_test.go
+++ b/jsoninfo/marshal_test.go
@@ -153,7 +153,6 @@ var Examples = []Example{
 }
 
 type Object map[string]interface{}
-type Array []interface{}
 
 func TestExtensions(t *testing.T) {
 	for _, example := range Examples {

--- a/jsoninfo/marshal_test.go
+++ b/jsoninfo/marshal_test.go
@@ -167,8 +167,7 @@ func TestExtensions(t *testing.T) {
 		// Unmarshal
 		if !example.NoUnmarshal {
 			t.Logf("Unmarshalling %T", x)
-			err = jsoninfo.UnmarshalStrictStruct(expectedData, x)
-			if err != nil {
+			if err := jsoninfo.UnmarshalStrictStruct(expectedData, x); err != nil {
 				t.Fatalf("Error unmarshalling %T: %v", x, err)
 			}
 			t.Logf("Marshalling %T", x)

--- a/jsoninfo/type_info.go
+++ b/jsoninfo/type_info.go
@@ -13,7 +13,6 @@ var (
 
 // TypeInfo contains information about JSON serialization of a type
 type TypeInfo struct {
-	mutex  sync.RWMutex
 	Type   reflect.Type
 	Fields []FieldInfo
 }

--- a/jsoninfo/unmarshal.go
+++ b/jsoninfo/unmarshal.go
@@ -24,9 +24,8 @@ type ObjectDecoder struct {
 
 func NewObjectDecoder(data []byte) (*ObjectDecoder, error) {
 	var remainingFields map[string]json.RawMessage
-	err := json.Unmarshal(data, &remainingFields)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal extension properties: %v\nInput: %s", err, string(data))
+	if err := json.Unmarshal(data, &remainingFields); err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal extension properties: %v\nInput: %s", err, data)
 	}
 	return &ObjectDecoder{
 		Data:            data,
@@ -81,8 +80,7 @@ func (decoder *ObjectDecoder) DecodeStructFieldsAndExtensions(value interface{})
 				isPtr = true
 			}
 			fieldValue := reflect.New(fieldType)
-			err := fieldValue.Interface().(json.Unmarshaler).UnmarshalJSON(fieldData)
-			if err != nil {
+			if err := fieldValue.Interface().(json.Unmarshaler).UnmarshalJSON(fieldData); err != nil {
 				if field.MultipleFields {
 					i := fieldIndex + 1
 					if i < len(fields) && fields[i].JSONName == field.JSONName {
@@ -104,8 +102,7 @@ func (decoder *ObjectDecoder) DecodeStructFieldsAndExtensions(value interface{})
 			if fieldPtr.Kind() != reflect.Ptr || fieldPtr.IsNil() {
 				fieldPtr = fieldPtr.Addr()
 			}
-			err := json.Unmarshal(fieldData, fieldPtr.Interface())
-			if err != nil {
+			if err := json.Unmarshal(fieldData, fieldPtr.Interface()); err != nil {
 				if field.MultipleFields {
 					i := fieldIndex + 1
 					if i < len(fields) && fields[i].JSONName == field.JSONName {

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -9,6 +9,7 @@ package openapi2
 
 import (
 	"fmt"
+
 	"github.com/jban332/kin-openapi/openapi3"
 )
 

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -2,6 +2,7 @@
 package openapi2conv
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -100,7 +101,7 @@ func ToV3PathItem(swagger *openapi2.Swagger, pathItem *openapi2.PathItem) (*open
 			return nil, err
 		}
 		if v3RequestBody != nil {
-			return nil, fmt.Errorf("PathItem shouldn't have a body parameter")
+			return nil, errors.New("PathItem shouldn't have a body parameter")
 		}
 		result.Parameters = append(result.Parameters, v3Parameter)
 	}
@@ -419,7 +420,7 @@ func FromV3RequestBody(swagger *openapi3.Swagger, operation *openapi3.Operation,
 
 	// If found an available name
 	if name == "" {
-		return nil, fmt.Errorf("Could not find a name for request body")
+		return nil, errors.New("Could not find a name for request body")
 	}
 	result := &openapi2.Parameter{
 		In:          "body",

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -3,9 +3,10 @@ package openapi2conv
 
 import (
 	"fmt"
+	"net/url"
+
 	"github.com/jban332/kin-openapi/openapi2"
 	"github.com/jban332/kin-openapi/openapi3"
-	"net/url"
 )
 
 func ToV3Swagger(swagger *openapi2.Swagger) (*openapi3.Swagger, error) {

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -3,11 +3,12 @@ package openapi2conv_test
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/jban332/kin-openapi/openapi2"
 	"github.com/jban332/kin-openapi/openapi2conv"
 	"github.com/jban332/kin-openapi/openapi3"
 	"github.com/jban332/kin-test/jsontest"
-	"testing"
 )
 
 type Object map[string]interface{}

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -152,8 +152,7 @@ func copyJSON(dest, src interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Failed to marshal %T: %v", src, err)
 	}
-	err = json.Unmarshal(data, dest)
-	if err != nil {
+	if err := json.Unmarshal(data, dest); err != nil {
 		return fmt.Errorf("Failed to unmarshal %T: %v", dest, err)
 	}
 	return nil
@@ -163,12 +162,10 @@ func Test_openapi2(t *testing.T) {
 	for _, example := range Examples {
 		swagger2 := &openapi2.Swagger{}
 		swagger3 := &openapi3.Swagger{}
-		err := copyJSON(swagger2, example.V2)
-		if err != nil {
+		if err := copyJSON(swagger2, example.V2); err != nil {
 			panic(err)
 		}
-		err = copyJSON(swagger3, example.V3)
-		if err != nil {
+		if err := copyJSON(swagger3, example.V3); err != nil {
 			panic(err)
 		}
 		t.Log("Converting V3 -> V2")

--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -3,8 +3,9 @@ package openapi3
 import (
 	"context"
 	"fmt"
-	"github.com/jban332/kin-openapi/jsoninfo"
 	"regexp"
+
+	"github.com/jban332/kin-openapi/jsoninfo"
 )
 
 // Components is specified by OpenAPI/Swagger standard version 3.0.

--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -26,12 +26,12 @@ func NewComponents() Components {
 	return Components{}
 }
 
-func (value *Components) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (components *Components) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(components)
 }
 
-func (value *Components) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (components *Components) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, components)
 }
 
 func (components *Components) Validate(c context.Context) error {

--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -35,68 +35,62 @@ func (components *Components) UnmarshalJSON(data []byte) error {
 	return jsoninfo.UnmarshalStrictStruct(data, components)
 }
 
-func (components *Components) Validate(c context.Context) error {
-	if m := components.Schemas; m != nil {
-		for k, v := range m {
-			if err := ValidateIdentifier(k); err != nil {
-				return err
-			}
-			if err := v.Validate(c); err != nil {
-				return err
-			}
+func (components *Components) Validate(c context.Context) (err error) {
+	for k, v := range components.Schemas {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(c); err != nil {
+			return
 		}
 	}
-	if m := components.Parameters; m != nil {
-		for k, v := range m {
-			if err := ValidateIdentifier(k); err != nil {
-				return err
-			}
-			if err := v.Validate(c); err != nil {
-				return err
-			}
+
+	for k, v := range components.Parameters {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(c); err != nil {
+			return
 		}
 	}
-	if m := components.RequestBodies; m != nil {
-		for k, v := range m {
-			if err := ValidateIdentifier(k); err != nil {
-				return err
-			}
-			if err := v.Validate(c); err != nil {
-				return err
-			}
+
+	for k, v := range components.RequestBodies {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(c); err != nil {
+			return
 		}
 	}
-	if m := components.Responses; m != nil {
-		for k, v := range m {
-			if err := ValidateIdentifier(k); err != nil {
-				return err
-			}
-			if err := v.Validate(c); err != nil {
-				return err
-			}
+
+	for k, v := range components.Responses {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(c); err != nil {
+			return
 		}
 	}
-	if m := components.Headers; m != nil {
-		for k, v := range m {
-			if err := ValidateIdentifier(k); err != nil {
-				return err
-			}
-			if err := v.Validate(c); err != nil {
-				return err
-			}
+
+	for k, v := range components.Headers {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(c); err != nil {
+			return
 		}
 	}
-	if m := components.SecuritySchemes; m != nil {
-		for k, v := range m {
-			if err := ValidateIdentifier(k); err != nil {
-				return err
-			}
-			if err := v.Validate(c); err != nil {
-				return err
-			}
+
+	for k, v := range components.SecuritySchemes {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(c); err != nil {
+			return
 		}
 	}
-	return nil
+
+	return
 }
 
 const identifierPattern = `^[a-zA-Z0-9.\-_]+$`

--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -24,15 +24,15 @@ func NewContentWithJSONSchemaRef(schema *SchemaRef) Content {
 	}
 }
 
-func (ct Content) Get(mime string) *ContentType {
-	if v := ct[mime]; v != nil {
+func (content Content) Get(mime string) *ContentType {
+	if v := content[mime]; v != nil {
 		return v
 	}
 	i := strings.IndexByte(mime, ';')
 	if i < 0 {
 		return nil
 	}
-	return ct[mime[:i]]
+	return content[mime[:i]]
 }
 
 func (content Content) Validate(c context.Context) error {
@@ -80,19 +80,19 @@ func (contentType *ContentType) WithExample(value interface{}) *ContentType {
 	return contentType
 }
 
-func (value *ContentType) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (contentType *ContentType) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(contentType)
 }
 
-func (value *ContentType) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (contentType *ContentType) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, contentType)
 }
 
-func (ct *ContentType) Validate(c context.Context) error {
-	if ct == nil {
+func (contentType *ContentType) Validate(c context.Context) error {
+	if contentType == nil {
 		return nil
 	}
-	if schema := ct.Schema; schema != nil {
+	if schema := contentType.Schema; schema != nil {
 		if err := schema.Validate(c); err != nil {
 			return err
 		}

--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -2,8 +2,9 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
 	"strings"
+
+	"github.com/jban332/kin-openapi/jsoninfo"
 )
 
 // Content is specified by OpenAPI/Swagger 3.0 standard.

--- a/openapi3/extension.go
+++ b/openapi3/extension.go
@@ -17,12 +17,9 @@ var _ jsoninfo.StrictStruct = &ExtensionProps{}
 
 // EncodeWith will be invoked by package "jsoninfo"
 func (props *ExtensionProps) EncodeWith(encoder *jsoninfo.ObjectEncoder, value interface{}) error {
-	if m := props.Extensions; m != nil {
-		for k, v := range m {
-			err := encoder.EncodeExtension(k, v)
-			if err != nil {
-				return err
-			}
+	for k, v := range props.Extensions {
+		if err := encoder.EncodeExtension(k, v); err != nil {
+			return err
 		}
 	}
 	return encoder.EncodeStructFieldsAndExtensions(value)
@@ -31,7 +28,7 @@ func (props *ExtensionProps) EncodeWith(encoder *jsoninfo.ObjectEncoder, value i
 // DecodeWith will be invoked by package "jsoninfo"
 func (props *ExtensionProps) DecodeWith(decoder *jsoninfo.ObjectDecoder, value interface{}) error {
 	source := decoder.DecodeExtensionMap()
-	if source != nil && len(source) > 0 {
+	if len(source) > 0 {
 		result := make(map[string]interface{}, len(source))
 		for k, v := range source {
 			result[k] = json.RawMessage(v)

--- a/openapi3/extension.go
+++ b/openapi3/extension.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"encoding/json"
+
 	"github.com/jban332/kin-openapi/jsoninfo"
 )
 

--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -16,8 +16,7 @@ type Header struct {
 
 func (value *Header) Validate(c context.Context) error {
 	if v := value.Schema; v != nil {
-		err := v.Validate(c)
-		if err != nil {
+		if err := v.Validate(c); err != nil {
 			return err
 		}
 	}

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+
 	"github.com/jban332/kin-openapi/jsoninfo"
 )
 

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -47,12 +47,12 @@ func NewOperation() *Operation {
 	return &Operation{}
 }
 
-func (value *Operation) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (operation *Operation) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(operation)
 }
 
-func (value *Operation) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (operation *Operation) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, operation)
 }
 
 func (operation *Operation) AddParameter(p *Parameter) {

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -2,8 +2,9 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
 	"strconv"
+
+	"github.com/jban332/kin-openapi/jsoninfo"
 )
 
 // Operation represents "operation" specified by" OpenAPI/Swagger 3.0 standard.

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"context"
 	"fmt"
+
 	"github.com/jban332/kin-openapi/jsoninfo"
 )
 

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -55,11 +55,11 @@ type Parameter struct {
 	Name            string        `json:"name,omitempty"`
 	In              string        `json:"in,omitempty"`
 	Description     string        `json:"description,omitempty"`
-	Deprecated      bool          `json:"deprecated,omitempty"`
-	Required        bool          `json:"required,omitempty"`
 	Style           string        `json:"style,omitempty"`
 	AllowEmptyValue bool          `json:"allowEmptyValue,omitempty"`
 	AllowReserved   bool          `json:"allowReserved,omitempty"`
+	Deprecated      bool          `json:"deprecated,omitempty"`
+	Required        bool          `json:"required,omitempty"`
 	Schema          *SchemaRef    `json:"schema,omitempty"`
 	Example         interface{}   `json:"example,omitempty"`
 	Examples        []interface{} `json:"examples,omitempty"`

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -13,8 +13,8 @@ func NewParameters() Parameters {
 	return make(Parameters, 0, 4)
 }
 
-func (all Parameters) GetByInAndName(in string, name string) *Parameter {
-	for _, item := range all {
+func (parameters Parameters) GetByInAndName(in string, name string) *Parameter {
+	for _, item := range parameters {
 		if v := item.Value; v != nil {
 			if v.Name == name && v.In == in {
 				return v
@@ -24,9 +24,9 @@ func (all Parameters) GetByInAndName(in string, name string) *Parameter {
 	return nil
 }
 
-func (all Parameters) Validate(c context.Context) error {
+func (parameters Parameters) Validate(c context.Context) error {
 	m := make(map[string]struct{})
-	for _, item := range all {
+	for _, item := range parameters {
 		err := item.Validate(c)
 		if err != nil {
 			return err
@@ -121,12 +121,12 @@ func (parameter *Parameter) WithSchema(value *Schema) *Parameter {
 	return parameter
 }
 
-func (value *Parameter) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (parameter *Parameter) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(parameter)
 }
 
-func (value *Parameter) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (parameter *Parameter) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, parameter)
 }
 
 func (parameter *Parameter) Validate(c context.Context) error {

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jban332/kin-openapi/jsoninfo"
@@ -28,8 +29,7 @@ func (parameters Parameters) GetByInAndName(in string, name string) *Parameter {
 func (parameters Parameters) Validate(c context.Context) error {
 	m := make(map[string]struct{})
 	for _, item := range parameters {
-		err := item.Validate(c)
-		if err != nil {
+		if err := item.Validate(c); err != nil {
 			return err
 		}
 		if v := item.Value; v != nil {
@@ -40,8 +40,7 @@ func (parameters Parameters) Validate(c context.Context) error {
 				return fmt.Errorf("More than one '%s' parameter has name '%s'", in, name)
 			}
 			m[key] = struct{}{}
-			err := item.Validate(c)
-			if err != nil {
+			if err := item.Validate(c); err != nil {
 				return err
 			}
 		}
@@ -132,7 +131,7 @@ func (parameter *Parameter) UnmarshalJSON(data []byte) error {
 
 func (parameter *Parameter) Validate(c context.Context) error {
 	if parameter.Name == "" {
-		return fmt.Errorf("Parameter name can't be blank")
+		return errors.New("Parameter name can't be blank")
 	}
 	in := parameter.In
 	switch in {
@@ -145,8 +144,7 @@ func (parameter *Parameter) Validate(c context.Context) error {
 		return fmt.Errorf("Parameter can't have 'in' value '%s'", parameter.In)
 	}
 	if schema := parameter.Schema; schema != nil {
-		err := schema.Validate(c)
-		if err != nil {
+		if err := schema.Validate(c); err != nil {
 			return fmt.Errorf("Parameter '%v' schema is invalid: %v", parameter.Name, err)
 		}
 	}

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"context"
 	"fmt"
+
 	"github.com/jban332/kin-openapi/jsoninfo"
 )
 

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -22,12 +22,12 @@ type PathItem struct {
 	Parameters  Parameters `json:"parameters,omitempty"`
 }
 
-func (value *PathItem) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (pathItem *PathItem) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(pathItem)
 }
 
-func (value *PathItem) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (pathItem *PathItem) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, pathItem)
 }
 
 func (pathItem *PathItem) Operations() map[string]*Operation {

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -105,8 +105,7 @@ func (pathItem *PathItem) SetOperation(method string, operation *Operation) {
 
 func (pathItem *PathItem) Validate(c context.Context) error {
 	for method, operation := range pathItem.Operations() {
-		err := operation.ValidateOperation(c, pathItem, method)
-		if err != nil {
+		if err := operation.ValidateOperation(c, pathItem, method); err != nil {
 			return err
 		}
 	}

--- a/openapi3/paths.go
+++ b/openapi3/paths.go
@@ -16,7 +16,7 @@ func (paths Paths) Validate(c context.Context) error {
 		if oldPath, exists := normalizedPaths[normalizedPath]; exists {
 			return fmt.Errorf("Conflicting paths '%v' and '%v'", path, oldPath)
 		}
-		if strings.HasPrefix(path, "/") == false {
+		if path == "" || path[0] != '/' {
 			return fmt.Errorf("Path '%v' does not start with '/'", path)
 		}
 		if strings.Contains(path, "//") {

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+
 	"github.com/jban332/kin-openapi/jsoninfo"
 )
 

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -61,8 +61,7 @@ func (requestBody *RequestBody) UnmarshalJSON(data []byte) error {
 
 func (requestBody *RequestBody) Validate(c context.Context) error {
 	if v := requestBody.Content; v != nil {
-		err := v.Validate(c)
-		if err != nil {
+		if err := v.Validate(c); err != nil {
 			return err
 		}
 	}

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -50,12 +50,12 @@ func (requestBody *RequestBody) GetContentType(mediaType string) *ContentType {
 	return m[mediaType]
 }
 
-func (value *RequestBody) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (requestBody *RequestBody) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(requestBody)
 }
 
-func (value *RequestBody) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (requestBody *RequestBody) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, requestBody)
 }
 
 func (requestBody *RequestBody) Validate(c context.Context) error {

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+
 	"github.com/jban332/kin-openapi/jsoninfo"
 )
 

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -24,8 +24,7 @@ func (responses Responses) Get(status int) *ResponseRef {
 
 func (responses Responses) Validate(c context.Context) error {
 	for _, v := range responses {
-		err := v.Validate(c)
-		if err != nil {
+		if err := v.Validate(c); err != nil {
 			return err
 		}
 	}

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -2,8 +2,9 @@ package openapi3
 
 import (
 	"context"
-	"github.com/jban332/kin-openapi/jsoninfo"
 	"strconv"
+
+	"github.com/jban332/kin-openapi/jsoninfo"
 )
 
 // Responses is specified by OpenAPI/Swagger 3.0 standard.

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -21,8 +21,8 @@ func (responses Responses) Get(status int) *ResponseRef {
 	return responses[strconv.FormatInt(int64(status), 10)]
 }
 
-func (all Responses) Validate(c context.Context) error {
-	for _, v := range all {
+func (responses Responses) Validate(c context.Context) error {
+	for _, v := range responses {
 		err := v.Validate(c)
 		if err != nil {
 			return err
@@ -64,12 +64,12 @@ func (response *Response) WithJSONSchemaRef(schema *SchemaRef) *Response {
 	return response
 }
 
-func (value *Response) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (response *Response) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(response)
 }
 
-func (value *Response) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (response *Response) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, response)
 }
 
 func (response *Response) Validate(c context.Context) error {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -391,7 +391,7 @@ func (schema *Schema) validate(c context.Context, stack []*Schema) error {
 	case "password":
 	case "array":
 		if schema.Items == nil {
-			return fmt.Errorf("When schema type is 'array', schema 'items' must be non-null")
+			return errors.New("When schema type is 'array', schema 'items' must be non-null")
 		}
 	case "object":
 	default:
@@ -506,8 +506,7 @@ func (schema *Schema) visitSetOperations(value interface{}, fast bool) error {
 			if v == nil {
 				return foundUnresolvedRef(item.Ref)
 			}
-			err := v.visitJSON(value, true)
-			if err == nil {
+			if err := v.visitJSON(value, true); err == nil {
 				ok++
 			}
 		}
@@ -529,8 +528,7 @@ func (schema *Schema) visitSetOperations(value interface{}, fast bool) error {
 			if v == nil {
 				return foundUnresolvedRef(item.Ref)
 			}
-			err := v.visitJSON(value, true)
-			if err == nil {
+			if err := v.visitJSON(value, true); err == nil {
 				ok = true
 				break
 			}
@@ -552,8 +550,7 @@ func (schema *Schema) visitSetOperations(value interface{}, fast bool) error {
 			if v == nil {
 				return foundUnresolvedRef(item.Ref)
 			}
-			err := v.visitJSON(value, true)
-			if err != nil {
+			if err := v.visitJSON(value, true); err != nil {
 				if fast {
 					return errSchema
 				}
@@ -569,12 +566,10 @@ func (schema *Schema) visitSetOperations(value interface{}, fast bool) error {
 }
 
 func (schema *Schema) visitJSONNull(fast bool) error {
-	err := schema.visitSetOperations(nil, fast)
-	if err != nil {
+	if err := schema.visitSetOperations(nil, fast); err != nil {
 		return err
 	}
-	err = schema.validateTypeListAllows("null", fast)
-	if err != nil {
+	if err := schema.validateTypeListAllows("null", fast); err != nil {
 		return err
 	}
 	if enum := schema.Enum; enum != nil {
@@ -643,8 +638,7 @@ func (schema *Schema) VisitJSONNumber(value float64) error {
 }
 
 func (schema *Schema) visitJSONNumber(value float64, fast bool) error {
-	err := schema.visitSetOperations(value, fast)
-	if err != nil {
+	if err := schema.visitSetOperations(value, fast); err != nil {
 		return err
 	}
 	if math.IsNaN(value) {
@@ -739,8 +733,7 @@ func (schema *Schema) VisitJSONString(value string) error {
 }
 
 func (schema *Schema) visitJSONString(value string, fast bool) error {
-	err := schema.visitSetOperations(value, fast)
-	if err != nil {
+	if err := schema.visitSetOperations(value, fast); err != nil {
 		return err
 	}
 	if err := schema.validateTypeListAllows("string", fast); err != nil {
@@ -853,12 +846,10 @@ func (schema *Schema) VisitJSONArray(value []interface{}) error {
 }
 
 func (schema *Schema) visitJSONArray(value []interface{}, fast bool) error {
-	err := schema.visitSetOperations(value, fast)
-	if err != nil {
+	if err := schema.visitSetOperations(value, fast); err != nil {
 		return err
 	}
-	err = schema.validateTypeListAllows("array", fast)
-	if err != nil {
+	if err := schema.validateTypeListAllows("array", fast); err != nil {
 		return err
 	}
 
@@ -895,8 +886,7 @@ func (schema *Schema) visitJSONArray(value []interface{}, fast bool) error {
 			return foundUnresolvedRef(itemSchemaRef.Ref)
 		}
 		for i, item := range value {
-			err := itemSchema.VisitJSON(item)
-			if err != nil {
+			if err := itemSchema.VisitJSON(item); err != nil {
 				return markSchemaErrorIndex(err, i)
 			}
 		}
@@ -909,12 +899,10 @@ func (schema *Schema) VisitJSONObject(value map[string]interface{}) error {
 }
 
 func (schema *Schema) visitJSONObject(value map[string]interface{}, fast bool) error {
-	err := schema.visitSetOperations(value, fast)
-	if err != nil {
+	if err := schema.visitSetOperations(value, fast); err != nil {
 		return err
 	}
-	err = schema.validateTypeListAllows("object", fast)
-	if err != nil {
+	if err := schema.validateTypeListAllows("object", fast); err != nil {
 		return err
 	}
 
@@ -952,8 +940,7 @@ func (schema *Schema) visitJSONObject(value map[string]interface{}, fast bool) e
 				if p == nil {
 					return foundUnresolvedRef(propertyRef.Ref)
 				}
-				err := p.VisitJSON(v)
-				if err != nil {
+				if err := p.VisitJSON(v); err != nil {
 					if fast {
 						return errSchema
 					}
@@ -973,8 +960,7 @@ func (schema *Schema) visitJSONObject(value map[string]interface{}, fast bool) e
 				}
 			}
 			if additionalProperties != nil {
-				err := additionalProperties.VisitJSON(v)
-				if err != nil {
+				if err := additionalProperties.VisitJSON(v); err != nil {
 					if fast {
 						return errSchema
 					}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -332,10 +332,10 @@ func (schema *Schema) TypesContains(value string) bool {
 }
 
 func (schema *Schema) Validate(c context.Context) error {
-	return schema.validate(make([]*Schema, 2), c)
+	return schema.validate(c, make([]*Schema, 2))
 }
 
-func (schema *Schema) validate(stack []*Schema, c context.Context) error {
+func (schema *Schema) validate(c context.Context, stack []*Schema) error {
 	for _, existing := range stack {
 		if existing == schema {
 			return nil
@@ -347,7 +347,7 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 		if v == nil {
 			return foundUnresolvedRef(item.Ref)
 		}
-		if err := v.validate(stack, c); err == nil {
+		if err := v.validate(c, stack); err == nil {
 			return err
 		}
 	}
@@ -356,7 +356,7 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 		if v == nil {
 			return foundUnresolvedRef(item.Ref)
 		}
-		if err := v.validate(stack, c); err != nil {
+		if err := v.validate(c, stack); err != nil {
 			return err
 		}
 	}
@@ -365,7 +365,7 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 		if v == nil {
 			return foundUnresolvedRef(item.Ref)
 		}
-		if err := v.validate(stack, c); err != nil {
+		if err := v.validate(c, stack); err != nil {
 			return err
 		}
 	}
@@ -374,7 +374,7 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 		if v == nil {
 			return foundUnresolvedRef(ref.Ref)
 		}
-		if err := v.validate(stack, c); err != nil {
+		if err := v.validate(c, stack); err != nil {
 			return err
 		}
 	}
@@ -402,7 +402,7 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 		if v == nil {
 			return foundUnresolvedRef(ref.Ref)
 		}
-		if err := v.validate(stack, c); err != nil {
+		if err := v.validate(c, stack); err != nil {
 			return err
 		}
 	}
@@ -411,7 +411,7 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 		if v == nil {
 			return foundUnresolvedRef(ref.Ref)
 		}
-		if err := v.validate(stack, c); err != nil {
+		if err := v.validate(c, stack); err != nil {
 			return err
 		}
 	}
@@ -420,7 +420,7 @@ func (schema *Schema) validate(stack []*Schema, c context.Context) error {
 		if v == nil {
 			return foundUnresolvedRef(ref.Ref)
 		}
-		if err := v.validate(stack, c); err != nil {
+		if err := v.validate(c, stack); err != nil {
 			return err
 		}
 	}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -82,17 +82,17 @@ func NewSchema() *Schema {
 	return &Schema{}
 }
 
-func (value *Schema) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (schema *Schema) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(schema)
 }
 
-func (value *Schema) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (schema *Schema) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, schema)
 }
 
-func (value *Schema) NewRef() *SchemaRef {
+func (schema *Schema) NewRef() *SchemaRef {
 	return &SchemaRef{
-		Value: value,
+		Value: schema,
 	}
 }
 

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1046,10 +1046,6 @@ func (schema *Schema) validateTypeListAllows(value string, fast bool) error {
 	}
 }
 
-func newSchemaError(schema *Schema, value interface{}, args ...interface{}) error {
-	return errors.New(fmt.Sprint(args...))
-}
-
 type SchemaError struct {
 	Value       interface{}
 	reversePath []string

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -43,6 +43,8 @@ type Schema struct {
 	Examples     []interface{} `json:"examples,omitempty"`
 	ExternalDocs interface{}   `json:"externalDocs,omitempty"`
 
+	// Object-related, here for struct compactness
+	AdditionalPropertiesAllowed bool `json:"-" multijson:"additionalProperties,omitempty"`
 	// Properties
 	Nullable  bool        `json:"nullable,omitempty"`
 	ReadOnly  bool        `json:"readOnly,omitempty"`
@@ -68,11 +70,10 @@ type Schema struct {
 	Items    *SchemaRef `json:"items,omitempty"`
 
 	// Object
-	Required                    []string              `json:"required,omitempty"`
-	Properties                  map[string]*SchemaRef `json:"properties,omitempty"`
-	AdditionalProperties        *SchemaRef            `json:"-" multijson:"additionalProperties,omitempty"`
-	AdditionalPropertiesAllowed bool                  `json:"-" multijson:"additionalProperties,omitempty"`
-	Discriminator               string                `json:"discriminator,omitempty"`
+	Required             []string              `json:"required,omitempty"`
+	Properties           map[string]*SchemaRef `json:"properties,omitempty"`
+	AdditionalProperties *SchemaRef            `json:"-" multijson:"additionalProperties,omitempty"`
+	Discriminator        string                `json:"discriminator,omitempty"`
 
 	PatternProperties         string `json:"patternProperties,omitempty"`
 	compiledPatternProperties *compiledPattern

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -2,9 +2,10 @@ package openapi3_test
 
 import (
 	"encoding/base64"
+	"testing"
+
 	"github.com/jban332/kin-openapi/openapi3"
 	"github.com/jban332/kin-test/jsontest"
-	"testing"
 )
 
 type SchemaExample struct {

--- a/openapi3/security_requirements.go
+++ b/openapi3/security_requirements.go
@@ -17,8 +17,7 @@ func (srs *SecurityRequirements) With(securityRequirement SecurityRequirement) *
 
 func (srs SecurityRequirements) Validate(c context.Context) error {
 	for _, item := range srs {
-		err := item.Validate(c)
-		if err != nil {
+		if err := item.Validate(c); err != nil {
 			return err
 		}
 	}

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -200,7 +200,7 @@ func (flow *OAuthFlow) Validate(c context.Context) error {
 	if v := flow.TokenURL; v == "" {
 		return fmt.Errorf("An OAuth flow is missing 'tokenUrl'")
 	}
-	if v := flow.Scopes; v == nil || len(v) == 0 {
+	if v := flow.Scopes; len(v) == 0 {
 		return fmt.Errorf("An OAuth flow is missing 'scopes'")
 	}
 	return nil

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/jban332/kin-openapi/jsoninfo"
 )
 

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -174,7 +174,7 @@ func (flows *OAuthFlows) Validate(c context.Context) error {
 	if v := flows.AuthorizationCode; v != nil {
 		return v.Validate(c)
 	}
-	return fmt.Errorf("No OAuth flow is defined")
+	return errors.New("No OAuth flow is defined")
 }
 
 type OAuthFlow struct {
@@ -195,13 +195,13 @@ func (flow *OAuthFlow) UnmarshalJSON(data []byte) error {
 
 func (flow *OAuthFlow) Validate(c context.Context) error {
 	if v := flow.AuthorizationURL; v == "" {
-		return fmt.Errorf("An OAuth flow is missing 'authorizationUrl'")
+		return errors.New("An OAuth flow is missing 'authorizationUrl'")
 	}
 	if v := flow.TokenURL; v == "" {
-		return fmt.Errorf("An OAuth flow is missing 'tokenUrl'")
+		return errors.New("An OAuth flow is missing 'tokenUrl'")
 	}
 	if v := flow.Scopes; len(v) == 0 {
-		return fmt.Errorf("An OAuth flow is missing 'scopes'")
+		return errors.New("An OAuth flow is missing 'scopes'")
 	}
 	return nil
 }

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -39,12 +39,12 @@ func NewJWTSecurityScheme() *SecurityScheme {
 	}
 }
 
-func (value *SecurityScheme) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (ss *SecurityScheme) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(ss)
 }
 
-func (value *SecurityScheme) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (ss *SecurityScheme) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, ss)
 }
 
 func (ss *SecurityScheme) WithType(value string) *SecurityScheme {
@@ -77,16 +77,16 @@ func (ss *SecurityScheme) WithBearerFormat(value string) *SecurityScheme {
 	return ss
 }
 
-func (securityScheme *SecurityScheme) Validate(c context.Context) error {
+func (ss *SecurityScheme) Validate(c context.Context) error {
 	hasIn := false
 	hasBearerFormat := false
 	hasFlow := false
-	switch securityScheme.Type {
+	switch ss.Type {
 	case "apiKey":
 		hasIn = true
 		hasBearerFormat = true
 	case "http":
-		scheme := securityScheme.Scheme
+		scheme := ss.Scheme
 		switch scheme {
 		case "bearer":
 			hasBearerFormat = true
@@ -97,51 +97,49 @@ func (securityScheme *SecurityScheme) Validate(c context.Context) error {
 	case "oauth2":
 		hasFlow = true
 	case "openIdConnect":
-		return fmt.Errorf("Support for security schemes with type '%v' has not been implemented", securityScheme.Type)
+		return fmt.Errorf("Support for security schemes with type '%v' has not been implemented", ss.Type)
 	default:
-		return fmt.Errorf("Security scheme 'type' can't be '%v'", securityScheme.Type)
+		return fmt.Errorf("Security scheme 'type' can't be '%v'", ss.Type)
 	}
 
 	// Validate "in" and "name"
 	if hasIn {
-		switch securityScheme.In {
+		switch ss.In {
 		case "query", "header":
 		default:
-			return fmt.Errorf("Security scheme of type 'apiKey' should have 'in'. It can be 'query' or 'header', not '%s'",
-				securityScheme.In)
+			return fmt.Errorf("Security scheme of type 'apiKey' should have 'in'. It can be 'query' or 'header', not '%s'", ss.In)
 		}
-		if securityScheme.Name == "" {
+		if ss.Name == "" {
 			return errors.New("Security scheme of type 'apiKey' should have 'name'")
 		}
-	} else if len(securityScheme.In) > 0 {
-		return fmt.Errorf("Security scheme of type '%s' can't have 'in'", securityScheme.Type)
-	} else if len(securityScheme.Name) > 0 {
+	} else if len(ss.In) > 0 {
+		return fmt.Errorf("Security scheme of type '%s' can't have 'in'", ss.Type)
+	} else if len(ss.Name) > 0 {
 		return errors.New("Security scheme of type 'apiKey' can't have 'name'")
 	}
 
 	// Validate "format"
 	if hasBearerFormat {
-		switch securityScheme.BearerFormat {
+		switch ss.BearerFormat {
 		case "", "JWT":
 		default:
-			return fmt.Errorf("Security scheme has unsupported 'bearerFormat' value '%s'", securityScheme.BearerFormat)
+			return fmt.Errorf("Security scheme has unsupported 'bearerFormat' value '%s'", ss.BearerFormat)
 		}
-	} else if len(securityScheme.BearerFormat) > 0 {
+	} else if len(ss.BearerFormat) > 0 {
 		return errors.New("Security scheme of type 'apiKey' can't have 'bearerFormat'")
 	}
 
 	// Validate "flow"
 	if hasFlow {
-		flow := securityScheme.Flow
+		flow := ss.Flow
 		if flow == nil {
-			return fmt.Errorf("Security scheme of type '%v' should have 'flow'", securityScheme.Type)
+			return fmt.Errorf("Security scheme of type '%v' should have 'flow'", ss.Type)
 		}
 		if err := flow.Validate(c); err != nil {
 			return fmt.Errorf("Security scheme 'flow' is invalid: %v", err)
 		}
-	} else if securityScheme.Flow != nil {
-		return fmt.Errorf("Security scheme of type '%s' can't have 'flow'",
-			securityScheme.Type)
+	} else if ss.Flow != nil {
+		return fmt.Errorf("Security scheme of type '%s' can't have 'flow'", ss.Type)
 	}
 	return nil
 }
@@ -154,12 +152,12 @@ type OAuthFlows struct {
 	AuthorizationCode *OAuthFlow `json:"authorizationCode,omitempty"`
 }
 
-func (value *OAuthFlows) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (flows *OAuthFlows) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(flows)
 }
 
-func (value *OAuthFlows) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (flows *OAuthFlows) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, flows)
 }
 
 func (flows *OAuthFlows) Validate(c context.Context) error {
@@ -186,12 +184,12 @@ type OAuthFlow struct {
 	Scopes           map[string]string `json:"scopes"`
 }
 
-func (value *OAuthFlow) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (flow *OAuthFlow) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(flow)
 }
 
-func (value *OAuthFlow) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (flow *OAuthFlow) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, flow)
 }
 
 func (flow *OAuthFlow) Validate(c context.Context) error {

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -2,7 +2,7 @@ package openapi3
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/url"
 	"strings"
 )
@@ -51,7 +51,7 @@ func (server Server) ParameterNames() ([]string, error) {
 		pattern = pattern[i+1:]
 		i = strings.IndexByte(pattern, '}')
 		if i < 0 {
-			return nil, fmt.Errorf("Missing '}'")
+			return nil, errors.New("Missing '}'")
 		}
 		params = append(params, strings.TrimSpace(pattern[:i]))
 		pattern = pattern[i+1:]
@@ -119,13 +119,13 @@ func (serverVariable *ServerVariable) Validate(c context.Context) error {
 	switch serverVariable.Default.(type) {
 	case float64, string:
 	default:
-		return fmt.Errorf("Variable 'default' must be either JSON number or JSON string")
+		return errors.New("Variable 'default' must be either JSON number or JSON string")
 	}
 	for _, item := range serverVariable.Enum {
 		switch item.(type) {
 		case float64, string:
 		default:
-			return fmt.Errorf("Every variable 'enum' item must be number of string")
+			return errors.New("Every variable 'enum' item must be number of string")
 		}
 	}
 	return nil

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -99,15 +99,13 @@ func (server Server) MatchRawURL(input string) ([]string, string, bool) {
 	return params, input, true
 }
 
-func (server *Server) Validate(c context.Context) error {
-	if m := server.Variables; m != nil {
-		for _, v := range m {
-			if err := v.Validate(c); err != nil {
-				return err
-			}
+func (server *Server) Validate(c context.Context) (err error) {
+	for _, v := range server.Variables {
+		if err = v.Validate(c); err != nil {
+			return
 		}
 	}
-	return nil
+	return
 }
 
 // ServerVariable is specified by OpenAPI/Swagger standard version 3.0.

--- a/openapi3/server_test.go
+++ b/openapi3/server_test.go
@@ -1,9 +1,10 @@
 package openapi3_test
 
 import (
+	"testing"
+
 	"github.com/jban332/kin-openapi/openapi3"
 	"github.com/jban332/kin-test/jsontest"
-	"testing"
 )
 
 type ServerMatch struct {

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -19,12 +19,12 @@ type Swagger struct {
 	visitedSchemas map[*Schema]struct{}
 }
 
-func (value *Swagger) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (swagger *Swagger) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(swagger)
 }
 
-func (value *Swagger) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (swagger *Swagger) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, swagger)
 }
 
 func (swagger *Swagger) AddOperation(path string, method string, operation *Operation) {

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -14,9 +14,6 @@ type Swagger struct {
 	Components   Components           `json:"components,omitempty"`
 	Security     SecurityRequirements `json:"security,omitempty"`
 	ExternalDocs *ExternalDocs        `json:"externalDocs,omitempty"`
-
-	// To prevent infinite recursion
-	visitedSchemas map[*Schema]struct{}
 }
 
 func (swagger *Swagger) MarshalJSON() ([]byte, error) {

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+
 	"github.com/jban332/kin-openapi/jsoninfo"
 )
 

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -74,13 +74,13 @@ func (swaggerLoader *SwaggerLoader) LoadSwaggerFromData(data []byte) (*Swagger, 
 	return swagger, swaggerLoader.ResolveRefsIn(swagger)
 }
 
-func (resolver *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
-	resolver.visited = make(map[interface{}]struct{})
+func (swaggerLoader *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
+	swaggerLoader.visited = make(map[interface{}]struct{})
 
 	// Visit all components
 	if m := swagger.Components.Headers; m != nil {
 		for _, component := range m {
-			err := resolver.resolveHeaderRef(swagger, component)
+			err := swaggerLoader.resolveHeaderRef(swagger, component)
 			if err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ func (resolver *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
 	}
 	if m := swagger.Components.Parameters; m != nil {
 		for _, component := range m {
-			err := resolver.resolveParameterRef(swagger, component)
+			err := swaggerLoader.resolveParameterRef(swagger, component)
 			if err != nil {
 				return err
 			}
@@ -96,7 +96,7 @@ func (resolver *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
 	}
 	if m := swagger.Components.RequestBodies; m != nil {
 		for _, component := range m {
-			err := resolver.resolveRequestBodyRef(swagger, component)
+			err := swaggerLoader.resolveRequestBodyRef(swagger, component)
 			if err != nil {
 				return err
 			}
@@ -104,7 +104,7 @@ func (resolver *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
 	}
 	if m := swagger.Components.Responses; m != nil {
 		for _, component := range m {
-			err := resolver.resolveResponseRef(swagger, component)
+			err := swaggerLoader.resolveResponseRef(swagger, component)
 			if err != nil {
 				return err
 			}
@@ -112,7 +112,7 @@ func (resolver *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
 	}
 	if m := swagger.Components.Schemas; m != nil {
 		for _, component := range m {
-			err := resolver.resolveSchemaRef(swagger, component)
+			err := swaggerLoader.resolveSchemaRef(swagger, component)
 			if err != nil {
 				return err
 			}
@@ -120,7 +120,7 @@ func (resolver *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
 	}
 	if m := swagger.Components.SecuritySchemes; m != nil {
 		for _, component := range m {
-			err := resolver.resolveSecuritySchemeRef(swagger, component)
+			err := swaggerLoader.resolveSecuritySchemeRef(swagger, component)
 			if err != nil {
 				return err
 			}
@@ -136,21 +136,21 @@ func (resolver *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
 			for _, operation := range pathItem.Operations() {
 				if parameters := operation.Parameters; parameters != nil {
 					for _, parameter := range parameters {
-						err := resolver.resolveParameterRef(swagger, parameter)
+						err := swaggerLoader.resolveParameterRef(swagger, parameter)
 						if err != nil {
 							return err
 						}
 					}
 				}
 				if requestBody := operation.RequestBody; requestBody != nil {
-					err := resolver.resolveRequestBodyRef(swagger, requestBody)
+					err := swaggerLoader.resolveRequestBodyRef(swagger, requestBody)
 					if err != nil {
 						return err
 					}
 				}
 				if responses := operation.Responses; responses != nil {
 					for _, response := range responses {
-						err := resolver.resolveResponseRef(swagger, response)
+						err := swaggerLoader.resolveResponseRef(swagger, response)
 						if err != nil {
 							return err
 						}
@@ -162,9 +162,9 @@ func (resolver *SwaggerLoader) ResolveRefsIn(swagger *Swagger) error {
 	return nil
 }
 
-func (resolver *SwaggerLoader) resolveComponent(swagger *Swagger, ref string, prefix string) (components *Components, id string, err error) {
+func (swaggerLoader *SwaggerLoader) resolveComponent(swagger *Swagger, ref string, prefix string) (components *Components, id string, err error) {
 	if !strings.HasPrefix(ref, "#") {
-		if !resolver.IsExternalRefsAllowed {
+		if !swaggerLoader.IsExternalRefsAllowed {
 			return nil, "", fmt.Errorf("Encountered non-allowed external reference: '%s'", ref)
 		}
 		parsedURL, err := url.Parse(ref)
@@ -173,7 +173,7 @@ func (resolver *SwaggerLoader) resolveComponent(swagger *Swagger, ref string, pr
 		}
 		fragment := parsedURL.Fragment
 		parsedURL.Fragment = ""
-		swagger, err = resolver.LoadSwaggerFromURI(parsedURL)
+		swagger, err = swaggerLoader.LoadSwaggerFromURI(parsedURL)
 		if err != nil {
 			return nil, "", fmt.Errorf("Error while resolving reference '%s': %v", ref, err)
 		}
@@ -189,9 +189,9 @@ func (resolver *SwaggerLoader) resolveComponent(swagger *Swagger, ref string, pr
 	return &swagger.Components, id, nil
 }
 
-func (resolver *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component *HeaderRef) error {
+func (swaggerLoader *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component *HeaderRef) error {
 	// Prevent infinite recursion
-	visited := resolver.visited
+	visited := swaggerLoader.visited
 	if _, isVisited := visited[component]; isVisited {
 		return nil
 	}
@@ -200,7 +200,7 @@ func (resolver *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component *Hea
 	// Resolve ref
 	const prefix = "#/components/headers/"
 	if ref := component.Ref; len(ref) > 0 {
-		components, id, err := resolver.resolveComponent(swagger, ref, prefix)
+		components, id, err := swaggerLoader.resolveComponent(swagger, ref, prefix)
 		if err != nil {
 			return err
 		}
@@ -212,7 +212,7 @@ func (resolver *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component *Hea
 		if resolved == nil {
 			return failedToResolveRefFragment(ref)
 		}
-		err = resolver.resolveHeaderRef(swagger, resolved)
+		err = swaggerLoader.resolveHeaderRef(swagger, resolved)
 		if err != nil {
 			return err
 		}
@@ -223,7 +223,7 @@ func (resolver *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component *Hea
 		return nil
 	}
 	if schema := value.Schema; schema != nil {
-		err := resolver.resolveSchemaRef(swagger, schema)
+		err := swaggerLoader.resolveSchemaRef(swagger, schema)
 		if err != nil {
 			return err
 		}
@@ -231,9 +231,9 @@ func (resolver *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component *Hea
 	return nil
 }
 
-func (resolver *SwaggerLoader) resolveParameterRef(swagger *Swagger, component *ParameterRef) error {
+func (swaggerLoader *SwaggerLoader) resolveParameterRef(swagger *Swagger, component *ParameterRef) error {
 	// Prevent infinite recursion
-	visited := resolver.visited
+	visited := swaggerLoader.visited
 	if _, isVisited := visited[component]; isVisited {
 		return nil
 	}
@@ -242,7 +242,7 @@ func (resolver *SwaggerLoader) resolveParameterRef(swagger *Swagger, component *
 	// Resolve ref
 	const prefix = "#/components/parameters/"
 	if ref := component.Ref; len(ref) > 0 {
-		components, id, err := resolver.resolveComponent(swagger, ref, prefix)
+		components, id, err := swaggerLoader.resolveComponent(swagger, ref, prefix)
 		if err != nil {
 			return err
 		}
@@ -254,7 +254,7 @@ func (resolver *SwaggerLoader) resolveParameterRef(swagger *Swagger, component *
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = resolver.resolveParameterRef(swagger, resolved)
+		err = swaggerLoader.resolveParameterRef(swagger, resolved)
 		if err != nil {
 			return err
 		}
@@ -265,7 +265,7 @@ func (resolver *SwaggerLoader) resolveParameterRef(swagger *Swagger, component *
 		return nil
 	}
 	if schema := value.Schema; schema != nil {
-		err := resolver.resolveSchemaRef(swagger, schema)
+		err := swaggerLoader.resolveSchemaRef(swagger, schema)
 		if err != nil {
 			return err
 		}
@@ -273,9 +273,9 @@ func (resolver *SwaggerLoader) resolveParameterRef(swagger *Swagger, component *
 	return nil
 }
 
-func (resolver *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, component *RequestBodyRef) error {
+func (swaggerLoader *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, component *RequestBodyRef) error {
 	// Prevent infinite recursion
-	visited := resolver.visited
+	visited := swaggerLoader.visited
 	if _, isVisited := visited[component]; isVisited {
 		return nil
 	}
@@ -284,7 +284,7 @@ func (resolver *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, component
 	// Resolve ref
 	const prefix = "#/components/requestBodies/"
 	if ref := component.Ref; len(ref) > 0 {
-		components, id, err := resolver.resolveComponent(swagger, ref, prefix)
+		components, id, err := swaggerLoader.resolveComponent(swagger, ref, prefix)
 		if err != nil {
 			return err
 		}
@@ -296,7 +296,7 @@ func (resolver *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, component
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = resolver.resolveRequestBodyRef(swagger, resolved)
+		err = swaggerLoader.resolveRequestBodyRef(swagger, resolved)
 		if err != nil {
 			return err
 		}
@@ -309,7 +309,7 @@ func (resolver *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, component
 	if content := value.Content; content != nil {
 		for _, contentType := range content {
 			if schema := contentType.Schema; schema != nil {
-				err := resolver.resolveSchemaRef(swagger, schema)
+				err := swaggerLoader.resolveSchemaRef(swagger, schema)
 				if err != nil {
 					return err
 				}
@@ -319,9 +319,9 @@ func (resolver *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, component
 	return nil
 }
 
-func (resolver *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *ResponseRef) error {
+func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *ResponseRef) error {
 	// Prevent infinite recursion
-	visited := resolver.visited
+	visited := swaggerLoader.visited
 	if _, isVisited := visited[component]; isVisited {
 		return nil
 	}
@@ -330,7 +330,7 @@ func (resolver *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *R
 	// Resolve ref
 	const prefix = "#/components/responses/"
 	if ref := component.Ref; len(ref) > 0 {
-		components, id, err := resolver.resolveComponent(swagger, ref, prefix)
+		components, id, err := swaggerLoader.resolveComponent(swagger, ref, prefix)
 		if err != nil {
 			return err
 		}
@@ -342,7 +342,7 @@ func (resolver *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *R
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = resolver.resolveResponseRef(swagger, resolved)
+		err = swaggerLoader.resolveResponseRef(swagger, resolved)
 		if err != nil {
 			return err
 		}
@@ -358,7 +358,7 @@ func (resolver *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *R
 				continue
 			}
 			if schema := contentType.Schema; schema != nil {
-				err := resolver.resolveSchemaRef(swagger, schema)
+				err := swaggerLoader.resolveSchemaRef(swagger, schema)
 				if err != nil {
 					return err
 				}
@@ -369,9 +369,9 @@ func (resolver *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *R
 	return nil
 }
 
-func (resolver *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component *SchemaRef) error {
+func (swaggerLoader *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component *SchemaRef) error {
 	// Prevent infinite recursion
-	visited := resolver.visited
+	visited := swaggerLoader.visited
 	if _, isVisited := visited[component]; isVisited {
 		return nil
 	}
@@ -380,7 +380,7 @@ func (resolver *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component *Sch
 	// Resolve ref
 	const prefix = "#/components/schemas/"
 	if ref := component.Ref; len(ref) > 0 {
-		components, id, err := resolver.resolveComponent(swagger, ref, prefix)
+		components, id, err := swaggerLoader.resolveComponent(swagger, ref, prefix)
 		if err != nil {
 			return err
 		}
@@ -392,7 +392,7 @@ func (resolver *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component *Sch
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = resolver.resolveSchemaRef(swagger, resolved)
+		err = swaggerLoader.resolveSchemaRef(swagger, resolved)
 		if err != nil {
 			return err
 		}
@@ -402,21 +402,21 @@ func (resolver *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component *Sch
 
 	// ResolveRefs referred schemas
 	if v := value.Items; v != nil {
-		err := resolver.resolveSchemaRef(swagger, v)
+		err := swaggerLoader.resolveSchemaRef(swagger, v)
 		if err != nil {
 			return err
 		}
 	}
 	if m := value.Properties; m != nil {
 		for _, v := range m {
-			err := resolver.resolveSchemaRef(swagger, v)
+			err := swaggerLoader.resolveSchemaRef(swagger, v)
 			if err != nil {
 				return err
 			}
 		}
 	}
 	if v := value.AdditionalProperties; v != nil {
-		err := resolver.resolveSchemaRef(swagger, v)
+		err := swaggerLoader.resolveSchemaRef(swagger, v)
 		if err != nil {
 			return err
 		}
@@ -424,9 +424,9 @@ func (resolver *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component *Sch
 	return nil
 }
 
-func (resolver *SwaggerLoader) resolveSecuritySchemeRef(swagger *Swagger, component *SecuritySchemeRef) error {
+func (swaggerLoader *SwaggerLoader) resolveSecuritySchemeRef(swagger *Swagger, component *SecuritySchemeRef) error {
 	// Prevent infinite recursion
-	visited := resolver.visited
+	visited := swaggerLoader.visited
 	if _, isVisited := visited[component]; isVisited {
 		return nil
 	}
@@ -435,7 +435,7 @@ func (resolver *SwaggerLoader) resolveSecuritySchemeRef(swagger *Swagger, compon
 	// Resolve ref
 	const prefix = "#/components/securitySchemes/"
 	if ref := component.Ref; len(ref) > 0 {
-		components, id, err := resolver.resolveComponent(swagger, ref, prefix)
+		components, id, err := swaggerLoader.resolveComponent(swagger, ref, prefix)
 		if err != nil {
 			return err
 		}
@@ -447,7 +447,7 @@ func (resolver *SwaggerLoader) resolveSecuritySchemeRef(swagger *Swagger, compon
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = resolver.resolveSecuritySchemeRef(swagger, resolved)
+		err = swaggerLoader.resolveSecuritySchemeRef(swagger, resolved)
 		if err != nil {
 			return err
 		}
@@ -456,10 +456,10 @@ func (resolver *SwaggerLoader) resolveSecuritySchemeRef(swagger *Swagger, compon
 	return nil
 }
 
-func (resolver *SwaggerLoader) resolveExampleRef(swagger *Swagger, component *ExampleRef) error {
+func (swaggerLoader *SwaggerLoader) resolveExampleRef(swagger *Swagger, component *ExampleRef) error {
 	const prefix = "#/components/examples"
 	if ref := component.Ref; len(ref) > 0 {
-		components, id, err := resolver.resolveComponent(swagger, ref, prefix)
+		components, id, err := swaggerLoader.resolveComponent(swagger, ref, prefix)
 		if err != nil {
 			return err
 		}
@@ -471,7 +471,7 @@ func (resolver *SwaggerLoader) resolveExampleRef(swagger *Swagger, component *Ex
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = resolver.resolveExampleRef(swagger, resolved)
+		err = swaggerLoader.resolveExampleRef(swagger, resolved)
 		if err != nil {
 			return err
 		}

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -63,8 +63,7 @@ func (swaggerLoader *SwaggerLoader) LoadSwaggerFromFile(path string) (*Swagger, 
 
 func (swaggerLoader *SwaggerLoader) LoadSwaggerFromData(data []byte) (*Swagger, error) {
 	swagger := &Swagger{}
-	err := json.Unmarshal(data, swagger)
-	if err != nil {
+	if err := json.Unmarshal(data, swagger); err != nil {
 		return nil, err
 	}
 	return swagger, swaggerLoader.ResolveRefsIn(swagger)
@@ -144,8 +143,7 @@ func (swaggerLoader *SwaggerLoader) resolveComponent(swagger *Swagger, ref strin
 		}
 		fragment := parsedURL.Fragment
 		parsedURL.Fragment = ""
-		swagger, err = swaggerLoader.LoadSwaggerFromURI(parsedURL)
-		if err != nil {
+		if swagger, err = swaggerLoader.LoadSwaggerFromURI(parsedURL); err != nil {
 			return nil, "", fmt.Errorf("Error while resolving reference '%s': %v", ref, err)
 		}
 		ref = fragment
@@ -183,8 +181,7 @@ func (swaggerLoader *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component
 		if resolved == nil {
 			return failedToResolveRefFragment(ref)
 		}
-		err = swaggerLoader.resolveHeaderRef(swagger, resolved)
-		if err != nil {
+		if err := swaggerLoader.resolveHeaderRef(swagger, resolved); err != nil {
 			return err
 		}
 		component.Value = resolved.Value
@@ -194,8 +191,7 @@ func (swaggerLoader *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component
 		return nil
 	}
 	if schema := value.Schema; schema != nil {
-		err := swaggerLoader.resolveSchemaRef(swagger, schema)
-		if err != nil {
+		if err := swaggerLoader.resolveSchemaRef(swagger, schema); err != nil {
 			return err
 		}
 	}
@@ -225,8 +221,7 @@ func (swaggerLoader *SwaggerLoader) resolveParameterRef(swagger *Swagger, compon
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = swaggerLoader.resolveParameterRef(swagger, resolved)
-		if err != nil {
+		if err := swaggerLoader.resolveParameterRef(swagger, resolved); err != nil {
 			return err
 		}
 		component.Value = resolved.Value
@@ -236,8 +231,7 @@ func (swaggerLoader *SwaggerLoader) resolveParameterRef(swagger *Swagger, compon
 		return nil
 	}
 	if schema := value.Schema; schema != nil {
-		err := swaggerLoader.resolveSchemaRef(swagger, schema)
-		if err != nil {
+		if err := swaggerLoader.resolveSchemaRef(swagger, schema); err != nil {
 			return err
 		}
 	}
@@ -267,8 +261,7 @@ func (swaggerLoader *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, comp
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = swaggerLoader.resolveRequestBodyRef(swagger, resolved)
-		if err != nil {
+		if err = swaggerLoader.resolveRequestBodyRef(swagger, resolved); err != nil {
 			return err
 		}
 		component.Value = resolved.Value
@@ -279,8 +272,7 @@ func (swaggerLoader *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, comp
 	}
 	for _, contentType := range value.Content {
 		if schema := contentType.Schema; schema != nil {
-			err := swaggerLoader.resolveSchemaRef(swagger, schema)
-			if err != nil {
+			if err := swaggerLoader.resolveSchemaRef(swagger, schema); err != nil {
 				return err
 			}
 		}
@@ -311,8 +303,7 @@ func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, compone
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = swaggerLoader.resolveResponseRef(swagger, resolved)
-		if err != nil {
+		if err := swaggerLoader.resolveResponseRef(swagger, resolved); err != nil {
 			return err
 		}
 		component.Value = resolved.Value
@@ -326,8 +317,7 @@ func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, compone
 			continue
 		}
 		if schema := contentType.Schema; schema != nil {
-			err := swaggerLoader.resolveSchemaRef(swagger, schema)
-			if err != nil {
+			if err := swaggerLoader.resolveSchemaRef(swagger, schema); err != nil {
 				return err
 			}
 			contentType.Schema = schema
@@ -359,8 +349,7 @@ func (swaggerLoader *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = swaggerLoader.resolveSchemaRef(swagger, resolved)
-		if err != nil {
+		if err := swaggerLoader.resolveSchemaRef(swagger, resolved); err != nil {
 			return err
 		}
 		component.Value = resolved.Value
@@ -369,8 +358,7 @@ func (swaggerLoader *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component
 
 	// ResolveRefs referred schemas
 	if v := value.Items; v != nil {
-		err := swaggerLoader.resolveSchemaRef(swagger, v)
-		if err != nil {
+		if err := swaggerLoader.resolveSchemaRef(swagger, v); err != nil {
 			return err
 		}
 	}
@@ -380,8 +368,7 @@ func (swaggerLoader *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component
 		}
 	}
 	if v := value.AdditionalProperties; v != nil {
-		err := swaggerLoader.resolveSchemaRef(swagger, v)
-		if err != nil {
+		if err := swaggerLoader.resolveSchemaRef(swagger, v); err != nil {
 			return err
 		}
 	}
@@ -411,8 +398,7 @@ func (swaggerLoader *SwaggerLoader) resolveSecuritySchemeRef(swagger *Swagger, c
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = swaggerLoader.resolveSecuritySchemeRef(swagger, resolved)
-		if err != nil {
+		if err := swaggerLoader.resolveSecuritySchemeRef(swagger, resolved); err != nil {
 			return err
 		}
 		component.Value = resolved.Value
@@ -435,8 +421,7 @@ func (swaggerLoader *SwaggerLoader) resolveExampleRef(swagger *Swagger, componen
 		if resolved == nil {
 			return failedToResolveRefFragmentPart(ref, id)
 		}
-		err = swaggerLoader.resolveExampleRef(swagger, resolved)
-		if err != nil {
+		if err := swaggerLoader.resolveExampleRef(swagger, resolved); err != nil {
 			return err
 		}
 		component.Value = resolved.Value

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -104,6 +104,11 @@ func (swaggerLoader *SwaggerLoader) ResolveRefsIn(swagger *Swagger) (err error) 
 			return
 		}
 	}
+	for _, component := range components.Examples {
+		if err = swaggerLoader.resolveExampleRef(swagger, component); err != nil {
+			return
+		}
+	}
 
 	// Visit all operations
 	for _, pathItem := range swagger.Paths {

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -13,10 +13,6 @@ func foundUnresolvedRef(ref string) error {
 	return fmt.Errorf("Found unresolved ref: '%s'", ref)
 }
 
-func failedToResolveRefDefinitions(value string) error {
-	return fmt.Errorf("Failed to resolve fragment in URI: '%s'", value)
-}
-
 func failedToResolveRefFragment(value string) error {
 	return fmt.Errorf("Failed to resolve fragment in URI: '%s'", value)
 }

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -2,6 +2,7 @@ package openapi3_test
 
 import (
 	"fmt"
+
 	"github.com/jban332/kin-openapi/openapi3"
 )
 

--- a/openapi3/swagger_test.go
+++ b/openapi3/swagger_test.go
@@ -3,9 +3,10 @@ package openapi3_test
 import (
 	"context"
 	"encoding/json"
+	"testing"
+
 	"github.com/jban332/kin-openapi/openapi3"
 	"github.com/jban332/kin-test/jsontest"
-	"testing"
 )
 
 type Array []interface{}

--- a/openapi3filter/authentication_input.go
+++ b/openapi3filter/authentication_input.go
@@ -2,8 +2,9 @@ package openapi3filter
 
 import (
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
 	"strings"
+
+	"github.com/jban332/kin-openapi/openapi3"
 )
 
 type AuthenticationInput struct {

--- a/openapi3filter/errors.go
+++ b/openapi3filter/errors.go
@@ -3,8 +3,9 @@ package openapi3filter
 import (
 	"errors"
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
 	"net/http"
+
+	"github.com/jban332/kin-openapi/openapi3"
 )
 
 var (

--- a/openapi3filter/router.go
+++ b/openapi3filter/router.go
@@ -102,18 +102,16 @@ func (router *Router) AddSwagger(swagger *openapi3.Swagger) error {
 	}
 	router.swagger = swagger
 	root := router.node()
-	if paths := swagger.Paths; paths != nil {
-		for path, pathItem := range paths {
-			for method, operation := range pathItem.Operations() {
-				method = strings.ToUpper(method)
-				root.Add(method+" "+path, &Route{
-					Swagger:   swagger,
-					Path:      path,
-					PathItem:  pathItem,
-					Method:    method,
-					Operation: operation,
-				}, nil)
-			}
+	for path, pathItem := range swagger.Paths {
+		for method, operation := range pathItem.Operations() {
+			method = strings.ToUpper(method)
+			root.Add(method+" "+path, &Route{
+				Swagger:   swagger,
+				Path:      path,
+				PathItem:  pathItem,
+				Method:    method,
+				Operation: operation,
+			}, nil)
 		}
 	}
 	return nil

--- a/openapi3filter/router.go
+++ b/openapi3filter/router.go
@@ -1,6 +1,7 @@
 package openapi3filter
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -96,8 +97,7 @@ func (router *Router) AddSwaggerFromFile(path string) error {
 
 // AddSwagger adds all operations in the OpenAPI specification.
 func (router *Router) AddSwagger(swagger *openapi3.Swagger) error {
-	err := swagger.Validate(nil)
-	if err != nil {
+	if err := swagger.Validate(context.TODO()); err != nil {
 		return fmt.Errorf("Validating Swagger failed: %v", err)
 	}
 	router.swagger = swagger

--- a/openapi3filter/router.go
+++ b/openapi3filter/router.go
@@ -70,8 +70,7 @@ func NewRouter() *Router {
 // WithSwaggerFromFile loads the Swagger file and adds it using WithSwagger.
 // Panics on any error.
 func (router *Router) WithSwaggerFromFile(path string) *Router {
-	err := router.AddSwaggerFromFile(path)
-	if err != nil {
+	if err := router.AddSwaggerFromFile(path); err != nil {
 		panic(err)
 	}
 	return router
@@ -80,8 +79,7 @@ func (router *Router) WithSwaggerFromFile(path string) *Router {
 // WithSwagger adds all operations in the OpenAPI specification.
 // Panics on any error.
 func (router *Router) WithSwagger(swagger *openapi3.Swagger) *Router {
-	err := router.AddSwagger(swagger)
-	if err != nil {
+	if err := router.AddSwagger(swagger); err != nil {
 		panic(err)
 	}
 	return router

--- a/openapi3filter/router.go
+++ b/openapi3filter/router.go
@@ -2,6 +2,7 @@ package openapi3filter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -105,30 +106,32 @@ func (router *Router) AddSwagger(swagger *openapi3.Swagger) error {
 	for path, pathItem := range swagger.Paths {
 		for method, operation := range pathItem.Operations() {
 			method = strings.ToUpper(method)
-			root.Add(method+" "+path, &Route{
+			if err := root.Add(method+" "+path, &Route{
 				Swagger:   swagger,
 				Path:      path,
 				PathItem:  pathItem,
 				Method:    method,
 				Operation: operation,
-			}, nil)
+			}, nil); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
 // AddRoute adds a route in the router.
-func (router *Router) AddRoute(route *Route) {
+func (router *Router) AddRoute(route *Route) error {
 	method := route.Method
 	if method == "" {
-		panic("Route is missing method")
+		return errors.New("Route is missing method")
 	}
 	method = strings.ToUpper(method)
 	path := route.Path
 	if path == "" {
-		panic("Route is missing path")
+		return errors.New("Route is missing path")
 	}
-	router.node().Add(method+" "+path, router, nil)
+	return router.node().Add(method+" "+path, router, nil)
 }
 
 func (router *Router) node() *pathpattern.Node {

--- a/openapi3filter/router.go
+++ b/openapi3filter/router.go
@@ -2,11 +2,12 @@ package openapi3filter
 
 import (
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-openapi/pathpattern"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/jban332/kin-openapi/pathpattern"
 )
 
 type Route struct {

--- a/openapi3filter/router_test.go
+++ b/openapi3filter/router_test.go
@@ -1,11 +1,12 @@
 package openapi3filter_test
 
 import (
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-openapi/openapi3filter"
 	"net/http"
 	"sort"
 	"testing"
+
+	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/jban332/kin-openapi/openapi3filter"
 )
 
 func TestRouter(t *testing.T) {

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -29,35 +29,28 @@ func ValidateRequest(c context.Context, input *RequestValidationInput) error {
 	pathItemParameters := route.PathItem.Parameters
 
 	// For each parameter of the PathItem
-	if pathItemParameters != nil {
-		for _, parameterRef := range pathItemParameters {
-			parameter := parameterRef.Value
-			if operationParameters != nil {
-				override := operationParameters.GetByInAndName(parameter.In, parameter.Name)
-				if override != nil {
-					continue
-				}
+	for _, parameterRef := range pathItemParameters {
+		parameter := parameterRef.Value
+		if operationParameters != nil {
+			if override := operationParameters.GetByInAndName(parameter.In, parameter.Name); override != nil {
+				continue
 			}
-			err := ValidateParameter(c, input, parameter)
-			if err != nil {
+			if err := ValidateParameter(c, input, parameter); err != nil {
 				return err
 			}
 		}
 	}
 
 	// For each parameter of the Operation
-	if operationParameters != nil {
-		for _, parameter := range operationParameters {
-			err := ValidateParameter(c, input, parameter.Value)
-			if err != nil {
-				return err
-			}
+	for _, parameter := range operationParameters {
+		if err := ValidateParameter(c, input, parameter.Value); err != nil {
+			return err
 		}
 	}
 
 	// RequestBody
 	requestBody := operation.RequestBody
-	if requestBody != nil && options.ExcludeRequestBody == false {
+	if requestBody != nil && !options.ExcludeRequestBody {
 		err := ValidateRequestBody(c, input, requestBody.Value)
 		if err != nil {
 			return err

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/jban332/kin-openapi/openapi3"
 	"io/ioutil"
 	"net/http"
 	"sort"
+
+	"github.com/jban332/kin-openapi/openapi3"
 )
 
 func ValidateRequest(c context.Context, input *RequestValidationInput) error {

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -273,13 +273,12 @@ func validateSecurityRequirement(c context.Context, input *RequestValidationInpu
 		return ErrAuthenticationServiceMissing
 	}
 
-	// Visit all requirements
-	for _, name := range names {
+	if len(names) > 0 {
+		name := names[0]
 		var securityScheme *openapi3.SecurityScheme
 		if securitySchemes != nil {
-			securitySchemeRef := securitySchemes[name]
-			if securitySchemeRef != nil {
-				securityScheme = securitySchemeRef.Value
+			if ref := securitySchemes[name]; ref != nil {
+				securityScheme = ref.Value
 			}
 		}
 		if securityScheme == nil {

--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -66,7 +66,7 @@ func ValidateResponse(c context.Context, input *ResponseValidationInput) error {
 			}
 		}
 		content := response.Content
-		if content != nil && len(content) > 0 && options.ExcludeResponseBody == false {
+		if len(content) > 0 && !options.ExcludeResponseBody {
 			inputMIME := input.Header.Get("Content-Type")
 			mediaType := parseMediaType(inputMIME)
 			contentType := content[mediaType]

--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -106,11 +106,7 @@ func ValidateResponse(c context.Context, input *ResponseValidationInput) error {
 
 				// Decode JSON
 				var value interface{}
-				err = json.Unmarshal(data, &value)
-				if err != nil {
-					return err
-				}
-				if err != nil {
+				if err := json.Unmarshal(data, &value); err != nil {
 					return &ResponseError{
 						Input:  input,
 						Reason: "decoding JSON in the input body failed",
@@ -119,8 +115,7 @@ func ValidateResponse(c context.Context, input *ResponseValidationInput) error {
 				}
 
 				// Validate JSON with the schema
-				err = schema.VisitJSON(value)
-				if err != nil {
+				if err := schema.VisitJSON(value); err != nil {
 					return &ResponseError{
 						Input: input,
 						Err:   err,

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -3,13 +3,14 @@ package openapi3filter_test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/jban332/kin-openapi/openapi3"
-	"github.com/jban332/kin-openapi/openapi3filter"
-	"github.com/jban332/kin-test/jsontest"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/jban332/kin-openapi/openapi3"
+	"github.com/jban332/kin-openapi/openapi3filter"
+	"github.com/jban332/kin-test/jsontest"
 )
 
 type ExampleRequest struct {

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -2,6 +2,7 @@ package openapi3filter_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -79,7 +80,7 @@ func TestFilter(t *testing.T) {
 			PathParams: pathParams,
 			Route:      route,
 		}
-		err = openapi3filter.ValidateRequest(nil, requestValidationInput)
+		err = openapi3filter.ValidateRequest(context.TODO(), requestValidationInput)
 		if err != nil {
 			return jsontest.ExpectWithErr(t, nil, err)
 		}
@@ -100,7 +101,7 @@ func TestFilter(t *testing.T) {
 			}
 			responseValidationInput.SetBodyBytes(data)
 		}
-		err = openapi3filter.ValidateResponse(nil, responseValidationInput)
+		err = openapi3filter.ValidateResponse(context.TODO(), responseValidationInput)
 		return jsontest.ExpectWithErr(t, nil, err)
 	}
 

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -80,8 +80,7 @@ func TestFilter(t *testing.T) {
 			PathParams: pathParams,
 			Route:      route,
 		}
-		err = openapi3filter.ValidateRequest(context.TODO(), requestValidationInput)
-		if err != nil {
+		if err := openapi3filter.ValidateRequest(context.TODO(), requestValidationInput); err != nil {
 			return jsontest.ExpectWithErr(t, nil, err)
 		}
 		t.Logf("Response: %d", resp.Status)

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -3,11 +3,12 @@ package openapi3gen
 
 import (
 	"encoding/json"
-	"github.com/jban332/kin-openapi/jsoninfo"
-	"github.com/jban332/kin-openapi/openapi3"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/jban332/kin-openapi/jsoninfo"
+	"github.com/jban332/kin-openapi/openapi3"
 )
 
 // CycleError indicates that a type graph has one or more possible cycles.

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -2,10 +2,11 @@ package openapi3gen_test
 
 import (
 	"encoding/json"
-	"github.com/jban332/kin-openapi/openapi3gen"
-	"github.com/jban332/kin-test/jsontest"
 	"testing"
 	"time"
+
+	"github.com/jban332/kin-openapi/openapi3gen"
+	"github.com/jban332/kin-test/jsontest"
 )
 
 type CyclicType0 struct {

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -43,7 +43,6 @@ type Example struct {
 
 type ExampleChild string
 
-type Array []interface{}
 type Object map[string]interface{}
 
 func TestSimple(t *testing.T) {

--- a/pathpattern/node.go
+++ b/pathpattern/node.go
@@ -59,20 +59,20 @@ type Node struct {
 	Suffixes      SuffixList
 }
 
-func (node *Node) String() string {
+func (currentNode *Node) String() string {
 	buf := bytes.NewBuffer(make([]byte, 0, 255))
-	node.toBuffer(buf, "")
+	currentNode.toBuffer(buf, "")
 	return buf.String()
 }
 
-func (node *Node) toBuffer(buf *bytes.Buffer, linePrefix string) {
-	if value := node.Value; value != nil {
+func (currentNode *Node) toBuffer(buf *bytes.Buffer, linePrefix string) {
+	if value := currentNode.Value; value != nil {
 		buf.WriteString(linePrefix)
 		buf.WriteString("VALUE: ")
 		fmt.Fprint(buf, value)
 		buf.WriteString("\n")
 	}
-	suffixes := node.Suffixes
+	suffixes := currentNode.Suffixes
 	if len(suffixes) > 0 {
 		newLinePrefix := linePrefix + "  "
 		for _, suffix := range suffixes {
@@ -262,27 +262,27 @@ loop:
 	}
 }
 
-func (node *Node) Match(path string) (*Node, []string) {
+func (currentNode *Node) Match(path string) (*Node, []string) {
 	for strings.HasSuffix(path, "/") {
 		path = path[:len(path)-1]
 	}
 	variableValues := make([]string, 0, 8)
-	return node.matchRemaining(path, false, variableValues)
+	return currentNode.matchRemaining(path, false, variableValues)
 }
 
-func (node *Node) matchRemaining(remaining string, hasExtraSlash bool, paramValues []string) (*Node, []string) {
+func (currentNode *Node) matchRemaining(remaining string, hasExtraSlash bool, paramValues []string) (*Node, []string) {
 	// Remove "/" from the beginning
 	// if len(remaining) > 0 && remaining[0] == '/' {
 	// 	remaining = remaining[1:]
 	// }
 
 	// Check if this node matches
-	if len(remaining) == 0 && node.Value != nil {
-		return node, paramValues
+	if len(remaining) == 0 && currentNode.Value != nil {
+		return currentNode, paramValues
 	}
 
 	// See if any suffix  matches
-	for _, suffix := range node.Suffixes {
+	for _, suffix := range currentNode.Suffixes {
 		var resultNode *Node
 		var resultValues []string
 		switch suffix.Kind {

--- a/pathpattern/node.go
+++ b/pathpattern/node.go
@@ -141,7 +141,7 @@ func (list SuffixList) Less(i, j int) bool {
 	} else if bk < ak {
 		return false
 	}
-	return b.Pattern <= b.Pattern
+	return a.Pattern <= b.Pattern
 }
 
 func (list SuffixList) Len() int {

--- a/pathpattern/node_test.go
+++ b/pathpattern/node_test.go
@@ -1,8 +1,9 @@
 package pathpattern_test
 
 import (
-	"github.com/jban332/kin-openapi/pathpattern"
 	"testing"
+
+	"github.com/jban332/kin-openapi/pathpattern"
 )
 
 func TestPatterns(t *testing.T) {


### PR DESCRIPTION
Fixes most warnings found by `golangci-lint run --enable-all`.
Note: also fixed the README typo mentioned in #6 

e2f282b2d5b100186585a3f72cc2b24073ff6c66 breaks some tests. Would you mind looking at it?

Thanks